### PR TITLE
LidarForwardPitch in settings.json

### DIFF
--- a/Unreal/Plugins/AirSim/Source/VehiclePawnWrapper.h
+++ b/Unreal/Plugins/AirSim/Source/VehiclePawnWrapper.h
@@ -90,6 +90,7 @@ public: //interface
     std::string getVehicleConfigName() const;
 
     int getRemoteControlID() const;
+    int getLidarForwardPitch() const;
 
 protected:
     UPROPERTY(VisibleAnywhere)


### PR DESCRIPTION
To use, put the desired forward angle in settings.json as PX4: {LidarForwardPitch: 45} for example. You can put it as a child of whatever vehicle type actually, but in our case will be PX4.